### PR TITLE
Add a script to build ansible-chatbot-service locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ MODEL := $(if $(MODEL),$(MODEL),"gpt-3.5-turbo")
 images: requirements.txt ## Build container images
 	scripts/build-container.sh
 
+images-aap: requirements.txt ## Build container images
+	scripts/build-container-aap.sh
+
 install-tools:	install-woke ## Install required utilities/tools
 	# OLS 1085: Service build failure issue caused by newest PDM version
 	# (right now we need to stick to PDM specified in pyproject.toml file)

--- a/scripts/build-container-aap.sh
+++ b/scripts/build-container-aap.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Build an ansible-chatbot-service image locally
+
+AAP_VERSION=v2.5
+LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ttakamiy/aap-rag-content:latest
+RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs
+
+CACHE_OPTS=""
+if [ -z "$OLS_NO_IMAGE_CACHE" ]; then
+  CACHE_OPTS="--no-cache"
+fi
+
+# To build container for local use
+podman build \
+  ${CACHE_OPTS} \
+  --build-arg=VERSION="${AAP_VERSION}" \
+  --build-arg=LIGHTSPEED_RAG_CONTENT_IMAGE="${LIGHTSPEED_RAG_CONTENT_IMAGE}" \
+  --build-arg=RAG_CONTENTS_SUB_FOLDER="${RAG_CONTENTS_SUB_FOLDER}" \
+  -t "${AAP_API_IMAGE:-quay.io/ansible/ansible-chatbot-service:latest}" \
+  -f Containerfile
+
+# To test-run for local development
+#
+#  podman run --rm \
+#    --name chatbot-8080 \
+#    -p 8080:8080 \
+#    -v ${PWD}/rcsconfig.yaml:/app-root/rcsconfig.yaml:Z \
+#    -e OPENAI_API_KEY=IGNORED  \
+#    quay.io/ansible/ansible-chatbot-service:latest


### PR DESCRIPTION
## Description

Add a script (`build-container-aap.sh`) to build ansible-chatbot-service locally.

`make images-aap` invokes `build-container-aap.sh` to build `quay.io/ansible/ansible-chatbot-service:latest`.

The generated image can be executed on local host with:
```
 podman run --rm \
   --name chatbot-8080 \
   -p 8080:8080 \
   -v ${PWD}/rcsconfig.yaml:/app-root/rcsconfig.yaml:Z \
   -e OPENAI_API_KEY=IGNORED  \
   quay.io/ansible/ansible-chatbot-service:latest
```
and REST API can be invoked by opening `http://localhost:8080/docs` in a web browser.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [AAP-34976](https://issues.redhat.com/browse/AAP-34976)
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
