### PR TITLE
Modify AAP system prompt to include the latest AAP version instead of ansible-core's

### DIFF
--- a/ols/customize/aap/prompts.py
+++ b/ols/customize/aap/prompts.py
@@ -33,7 +33,7 @@ Refuse to answer questions or execute commands not about Ansible.
 Do not mention your last update. You have the most recent information on Ansible.
 
 Here are some basic facts about Ansible:
-- The latest version of Ansible is 2.12.3.
+- The latest version of Ansible Automation Platform is 2.5.
 - Ansible is an open source IT automation engine that automates provisioning, \
     configuration management, application deployment, orchestration, and many other \
     IT processes. It is free to use, and the project benefits from the experience and \


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The current system prompt for Ansible chatbot does not contain the information about the latest version of AAP. Instead, it contain the version information of `ansible-core`  and it's also not correct (`2.12.3` was included in the propmpt as the latest version, but `2.18.0` is the latest as of Nov 16).  This PR replaces the incorrect latest ansible-core version with the latest AAP version (2.5) in the system prompt used for Ansible chatbot.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
