### PR TITLE
Move RAG image to Ansible repository

### DIFF
--- a/.tekton/ansible-chatbot-service-pull-request.yaml
+++ b/.tekton/ansible-chatbot-service-pull-request.yaml
@@ -258,7 +258,7 @@ spec:
           - name: COMMIT_SHA
             value: $(tasks.clone-repository.results.commit)
           - name: BUILD_ARGS
-            value: ["IMAGE_TAGS=pr-{{pull_request_number}} pr-{{pull_request_number}}.$(tasks.git-metadata.results.commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)", "RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs", "LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ttakamiy/aap-rag-content:latest"]
+            value: ["IMAGE_TAGS=pr-{{pull_request_number}} pr-{{pull_request_number}}.$(tasks.git-metadata.results.commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)", "RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs", "LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ansible/aap-rag-content:latest"]
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
         runAfter:

--- a/.tekton/ansible-chatbot-service-push.yaml
+++ b/.tekton/ansible-chatbot-service-push.yaml
@@ -274,7 +274,7 @@ spec:
           - name: TARGET_STAGE
             value: production
           - name: BUILD_ARGS
-            value: [ "IMAGE_TAGS=latest 1.0.$(tasks.git-metadata.results.commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)", "RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs", "LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ttakamiy/aap-rag-content:latest"]
+            value: [ "IMAGE_TAGS=latest 1.0.$(tasks.git-metadata.results.commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)", "RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs", "LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ansible/aap-rag-content:latest"]
         runAfter:
           - prefetch-dependencies
         taskRef:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Move Ansible chatbot RAG image from a repository under Tami's personal quay account to a repository under Ansible (quay.io/ansible/aap-rag-content).


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [X] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [AAP-34876](https://issues.redhat.com/browse/AAP-34876)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
