### PR TITLE
Add the default (no-op) reranker for AAP

### DIFF
--- a/ols/customize/aap/reranker.py
+++ b/ols/customize/aap/reranker.py
@@ -1,0 +1,14 @@
+"""Reranker for post-processing the Vector DB search results."""
+
+import logging
+
+from llama_index.core.schema import NodeWithScore
+
+logger = logging.getLogger(__name__)
+
+
+def rerank(retrieved_nodes: list[NodeWithScore]) -> list[NodeWithScore]:
+    """Rerank Vector DB search results."""
+    message = f"reranker.rerank() is called with {len(retrieved_nodes)} result(s)."
+    logger.debug(message)
+    return retrieved_nodes


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This is add the default (no-op) "reranker" for AAP.  See https://github.com/road-core/service/pull/228 for more details. 

Note: It does nothing by default and it is not even called until https://github.com/road-core/service/pull/255 is included in the next rebase.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
