### PR TITLE
Containerfile change for fixing a Konflux build issue

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,6 +34,7 @@ COPY --from=lightspeed-rag-content /rag/embeddings_model ./embeddings_model
 # (avoid accidental inclusion of local directories or env files or credentials)
 COPY runner.py requirements.txt ./
 
+RUN pip3.11 install --upgrade pip
 RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 COPY ols ./ols


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fix a konflux build issue.
```
Collecting httpx>=0.22.0
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    httpx>=0.22.0 from https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl (from hishel==0.1.1->-r requirements.txt (line 264))
subprocess exited with status 1
subprocess exited with status 1
```
This seems to be resolved by upgrading `pip`.  That's what this PR is about.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
