### PR TITLE
Build ansible-chatbot-service image onto embeddings image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,9 +5,8 @@ ARG RAG_CONTENTS_SUB_FOLDER=vector_db/ocp_product_docs
 
 FROM ${LIGHTSPEED_RAG_CONTENT_IMAGE} as lightspeed-rag-content
 
-FROM ${LIGHTSPEED_RAG_EMBEDDINGS_IMAGE} as lightspeed-rag-embeddings
-
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS production
+FROM ${LIGHTSPEED_RAG_EMBEDDINGS_IMAGE} as production
+USER 0
 
 ARG APP_ROOT=/app-root
 
@@ -28,7 +27,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app-root
 
 COPY --from=lightspeed-rag-content /rag/${RAG_CONTENTS_SUB_FOLDER} ${APP_ROOT}/${RAG_CONTENTS_SUB_FOLDER}
-COPY --from=lightspeed-rag-embeddings /rag/embeddings_model ./embeddings_model
 
 # Add explicit files and directories
 # (avoid accidental inclusion of local directories or env files or credentials)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,8 @@ description = "Road-core service is an AI powered assistant that runs on OpenShi
 authors = []
 dependencies = [
     "pdm==2.21.0",
-    'torch@http://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl ; platform_system != "Darwin"',
-    'torch-macos@http://download.pytorch.org/whl/cpu/torch-2.5.1-cp311-none-macosx_11_0_arm64.whl ; platform_system == "Darwin"',
+    "torch@http://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl ; platform_system != \"Darwin\"",
+    "torch-macos@http://download.pytorch.org/whl/cpu/torch-2.5.1-cp311-none-macosx_11_0_arm64.whl ; platform_system == \"Darwin\"",
     "pandas==2.1.4",
     "httpx==0.27.2",
     "fastapi==0.115.6",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Build ansible-chatbot-service image using the RAG embeddings image as BASE.
With this change, Konflux build needs to push only the service image part and does not need to push the big embaddings (about 3 GB) at every build.

This PR also contains a small change in `pyproject.toml` (single quotes --> double quotes), which was suggested by @romartin 

## Type of change

- [X] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [AAP-38384](https://issues.redhat.com/browse/AAP-38384)
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
