### PR TITLE
Update chatbot image when RAG image is updated

### DIFF
--- a/.tekton/ansible-chatbot-service-pull-request.yaml
+++ b/.tekton/ansible-chatbot-service-pull-request.yaml
@@ -266,7 +266,12 @@ spec:
           - name: COMMIT_SHA
             value: $(tasks.clone-repository.results.commit)
           - name: BUILD_ARGS
-            value: ["IMAGE_TAGS=pr-{{pull_request_number}} pr-{{pull_request_number}}.$(tasks.git-metadata.results.commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)", "RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs", "LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ansible/aap-rag-content:latest", "LIGHTSPEED_RAG_EMBEDDINGS_IMAGE=quay.io/ansible/aap-rag-embeddings-image:latest"]
+            value:
+            - IMAGE_TAGS=pr-{{pull_request_number}} pr-{{pull_request_number}}.$(tasks.git-metadata.results.commit-timestamp)
+            - GIT_COMMIT=$(tasks.clone-repository.results.commit)
+            - RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs
+            - LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ansible/aap-rag-content:1.0.1739753069
+            - LIGHTSPEED_RAG_EMBEDDINGS_IMAGE=quay.io/ansible/aap-rag-embeddings-image:latest
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
         runAfter:

--- a/.tekton/ansible-chatbot-service-push.yaml
+++ b/.tekton/ansible-chatbot-service-push.yaml
@@ -282,7 +282,12 @@ spec:
           - name: TARGET_STAGE
             value: production
           - name: BUILD_ARGS
-            value: [ "IMAGE_TAGS=latest 1.0.$(tasks.git-metadata.results.commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)", "RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs", "LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ansible/aap-rag-content:latest", "LIGHTSPEED_RAG_EMBEDDINGS_IMAGE=quay.io/ansible/aap-rag-embeddings-image:latest"]
+            value:
+            - IMAGE_TAGS=latest 1.0.$(tasks.git-metadata.results.commit-timestamp)
+            - GIT_COMMIT=$(tasks.clone-repository.results.commit)
+            - RAG_CONTENTS_SUB_FOLDER=vector_db/aap_product_docs
+            - LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/ansible/aap-rag-content:1.0.1739753069
+            - LIGHTSPEED_RAG_EMBEDDINGS_IMAGE=quay.io/ansible/aap-rag-embeddings-image:latest
         runAfter:
           - prefetch-dependencies
         taskRef:

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "customManagers": [
+      {
+        "customType": "regex",
+        "datasourceTemplate": "docker",
+        "fileMatch": ["^\\.tekton/.+\\.yaml$"],
+        "matchStrings": [
+          "_IMAGE=(?<depName>[^:]+):(?<currentValue>[\\d\\.]+)"
+        ],
+        "versioningTemplate": "semver"
+      }
+    ],
+    "automerge": true
+  }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
For [AAP-37207](https://issues.redhat.com/browse/AAP-37207).
Trigger chatbot service image build when RAG content image is updated using renovate ([reference](https://docs.renovatebot.com/docker/))

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [AAP-37207](https://issues.redhat.com/browse/AAP-37207)
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
