### PR TITLE
Konflux push build references non-existent task build-image-index

### DIFF
--- a/.tekton/ansible-chatbot-service-push.yaml
+++ b/.tekton/ansible-chatbot-service-push.yaml
@@ -373,11 +373,11 @@ spec:
       - name: sast-shell-check
         params:
           - name: image-digest
-            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
           - name: image-url
-            value: $(tasks.build-image-index.results.IMAGE_URL)
+            value: $(tasks.build-container.results.IMAGE_URL)
         runAfter:
-          - build-image-index
+          - build-container
         taskRef:
           params:
             - name: name
@@ -398,9 +398,9 @@ spec:
       - name: sast-unicode-check
         params:
           - name: image-url
-            value: $(tasks.build-image-index.results.IMAGE_URL)
+            value: $(tasks.build-container.results.IMAGE_URL)
         runAfter:
-          - build-image-index
+          - build-container
         taskRef:
           params:
             - name: name


### PR DESCRIPTION
## Description

ansible-chatbot-service Konflux push builds have been failing since last month ([example](https://github.com/ansible/ansible-chatbot-service/runs/40643529758)).

The build script references a non-existent task `build-image-index`. According to the pull-result script, it should have been `build-container`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
