### PR TITLE
Chatbot Service fails with Granite 3.1 model

### DIFF
--- a/ols/src/llms/providers/rhelai_vllm.py
+++ b/ols/src/llms/providers/rhelai_vllm.py
@@ -9,6 +9,7 @@ from langchain_openai import ChatOpenAI
 from ols import constants
 from ols.src.llms.providers.provider import LLMProvider
 from ols.src.llms.providers.registry import register_llm_provider_as
+from ols.src.llms.providers.rhoai_vllm import ChatRHOAI
 
 logger = logging.getLogger(__name__)
 
@@ -49,4 +50,4 @@ class RHELAIVLLM(LLMProvider):
 
     def load(self) -> LLM:
         """Load LLM."""
-        return ChatOpenAI(**self.params)
+        return ChatRHOAI(**self.params)

--- a/ols/src/llms/providers/rhoai_vllm.py
+++ b/ols/src/llms/providers/rhoai_vllm.py
@@ -1,9 +1,10 @@
 """Red Hat OpenShift VLLM provider implementation."""
 
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 from langchain.llms.base import LLM
+from langchain_core.language_models import LanguageModelInput
 from langchain_openai import ChatOpenAI
 
 from ols import constants
@@ -49,4 +50,13 @@ class RHOAIVLLM(LLMProvider):
 
     def load(self) -> LLM:
         """Load LLM."""
-        return ChatOpenAI(**self.params)
+        return ChatRHOAI(**self.params)
+
+
+class ChatRHOAI(ChatOpenAI):
+    """ Workaround for the compatibility issue between max_tokens and max_completion_tokens """
+    def _get_request_payload(self, input_: LanguageModelInput, *, stop: Optional[List[str]] = None, **kwargs: Any) -> dict:
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        if "max_completion_tokens" in payload:
+            payload["max_tokens"] = payload.pop("max_completion_tokens")
+        return payload


### PR DESCRIPTION
## Description

[AAP-45939](https://issues.redhat.com/browse/AAP-45939)

Ansible chatbot service fails on inference with Granite 3.1 model.  The error shown on Gradio UI is:
```
 Sorry, an error occurred: {"detail":{"response":"[{'type': 'extra_forbidden', 'loc': ('body', 'max_completion_tokens'), 'msg': 'Extra inputs are not permitted', 'input': 1024}]","cause":"Error code: 400 - {'object': 'error', 'message': "[{'type': 'extra_forbidden', 'loc': ('body', 'max_completion_tokens'), 'msg': 'Extra inputs are not permitted', 'input': 1024}]", 'type': 'BadRequestError', 'param': None, 'code': 400}"}}
```
It is considered as the same problem as [this open langchain issue](https://github.com/langchain-ai/langchain/issues/29954).


## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [AAP-45939](https://issues.redhat.com/browse/AAP-45939)
- Closes # [AAP-45939](https://issues.redhat.com/browse/AAP-45939)

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
